### PR TITLE
Fix issue where setting callback on GLFW Window doesn't return the previous callback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ subprojects {
 			sourceSets.all {
 				languageSettings.apply {
 					enableLanguageFeature("InlineClasses")
+					enableLanguageFeature("NewInference")
 					useExperimentalAnnotation("kotlin.ExperimentalUnsignedTypes")
 					useExperimentalAnnotation("io.ktor.utils.io.core.ExperimentalIoApi")
 				}

--- a/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Window.kt
@@ -68,23 +68,23 @@ expect class Window : Closeable {
 	fun getKey(key: KeyboardKey): Action
 	fun getMouseButton(button: MouseButton): Action
 
-	fun setPosCallback(callback: WindowPosCallback?)
-	fun setSizeCallback(callback: WindowSizeCallback?)
-	fun setCloseCallback(callback: WindowCloseCallback?)
-	fun setRefreshCallback(callback: WindowRefreshCallback?)
-	fun setFocusCallback(callback: WindowFocusCallback?)
-	fun setIconifyCallback(callback: WindowIconifyCallback?)
-	fun setMaximizeCallback(callback: WindowMaximizeCallback?)
-	fun setContentScaleCallback(callback: WindowContentScaleCallback?)
-	fun setScrollCallback(callback: ScrollCallback?)
-	fun setCursorEnterCallback(callback: CursorEnterCallback?)
-	fun setCursorPosCallback(callback: CursorPosCallback?)
-	fun setFrameBufferCallback(callback: FrameBufferCallback?)
-	fun setDropCallback(callback: DropCallback?)
-	fun setKeyCallback(callback: KeyCallback?)
-	fun setMouseButtonCallback(callback: MouseButtonCallback?)
-	fun setCharCallback(callback: CharCallback?)
-	fun setCharModsCallback(callback: CharModsCallback?)
+	fun setPosCallback(callback: WindowPosCallback?): WindowPosCallback?
+	fun setSizeCallback(callback: WindowSizeCallback?): WindowSizeCallback?
+	fun setCloseCallback(callback: WindowCloseCallback?): WindowCloseCallback?
+	fun setRefreshCallback(callback: WindowRefreshCallback?): WindowRefreshCallback?
+	fun setFocusCallback(callback: WindowFocusCallback?): WindowFocusCallback?
+	fun setIconifyCallback(callback: WindowIconifyCallback?): WindowIconifyCallback?
+	fun setMaximizeCallback(callback: WindowMaximizeCallback?): WindowMaximizeCallback?
+	fun setContentScaleCallback(callback: WindowContentScaleCallback?): WindowContentScaleCallback?
+	fun setScrollCallback(callback: ScrollCallback?): ScrollCallback?
+	fun setCursorEnterCallback(callback: CursorEnterCallback?): CursorEnterCallback?
+	fun setCursorPosCallback(callback: CursorPosCallback?): CursorPosCallback?
+	fun setFrameBufferCallback(callback: FrameBufferCallback?): FrameBufferCallback?
+	fun setDropCallback(callback: DropCallback?): DropCallback?
+	fun setKeyCallback(callback: KeyCallback?): KeyCallback?
+	fun setMouseButtonCallback(callback: MouseButtonCallback?): MouseButtonCallback?
+	fun setCharCallback(callback: CharCallback?): CharCallback?
+	fun setCharModsCallback(callback: CharModsCallback?): CharModsCallback?
 
 	companion object {
 		inline operator fun invoke(

--- a/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Window.kt
@@ -310,10 +310,14 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		propSetter(callback)
 
 		if (callback != null) {
-			realSetter(ptr, getNativeCallback())
+			// only set the native callback if there was no callback set,
+			// since the native callback has a reference to the property
+			if (previous == null) {
+				realSetter(ptr, getNativeCallback())?.free()
+			}
 		} else {
-			realSetter(ptr, null)
-		}?.free()
+			realSetter(ptr, null)?.free()
+		}
 
 		return previous
 	}

--- a/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Window.kt
@@ -267,7 +267,27 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 
 	actual fun getMouseButton(button: MouseButton): Action = Action.from(glfwGetMouseButton(ptr, button.value))
 
-	actual fun setPosCallback(callback: WindowPosCallback?) {
+	private var windowPosCallback: WindowPosCallback? = null
+	private var windowSizeCallback: WindowSizeCallback? = null
+	private var frameBufferCallback: FrameBufferCallback? = null
+	private var windowCloseCallback: WindowCloseCallback? = null
+	private var windowRefreshCallback: WindowRefreshCallback? = null
+	private var windowFocusCallback: WindowFocusCallback? = null
+	private var windowMaximizeCallback: WindowMaximizeCallback? = null
+	private var windowIconifyCallback: WindowIconifyCallback? = null
+	private var cursorEnterCallback: CursorEnterCallback? = null
+	private var windowContentScaleCallback: WindowContentScaleCallback? = null
+	private var cursorPosCallback: CursorPosCallback? = null
+	private var scrollCallback: ScrollCallback? = null
+	private var dropCallback: DropCallback? = null
+	private var keyCallback: KeyCallback? = null
+	private var mouseButtonCallback: MouseButtonCallback? = null
+	private var charCallback: CharCallback? = null
+	private var charModsCallback: CharModsCallback? = null
+
+	actual fun setPosCallback(callback: WindowPosCallback?): WindowPosCallback? {
+		val previous = windowPosCallback
+		windowPosCallback = callback
 		if (callback != null) {
 			glfwSetWindowPosCallback(ptr) { _, x, y ->
 				callback(this, x, y)
@@ -275,9 +295,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowPosCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setSizeCallback(callback: WindowSizeCallback?) {
+	actual fun setSizeCallback(callback: WindowSizeCallback?): WindowSizeCallback? {
+		val previous = windowSizeCallback
+		windowSizeCallback = callback
 		if (callback != null) {
 			glfwSetWindowSizeCallback(ptr) { _, width, height ->
 				callback(this, width, height)
@@ -285,9 +308,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowSizeCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setFrameBufferCallback(callback: FrameBufferCallback?) {
+	actual fun setFrameBufferCallback(callback: FrameBufferCallback?): FrameBufferCallback? {
+		val previous = frameBufferCallback
+		frameBufferCallback = callback
 		if (callback != null) {
 			glfwSetFramebufferSizeCallback(ptr) { _, width, height ->
 				callback(this, width, height)
@@ -295,9 +321,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetFramebufferSizeCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setCloseCallback(callback: WindowCloseCallback?) {
+	actual fun setCloseCallback(callback: WindowCloseCallback?): WindowCloseCallback? {
+		val previous = windowCloseCallback
+		windowCloseCallback = callback
 		if (callback != null) {
 			glfwSetWindowCloseCallback(ptr) {
 				callback(this)
@@ -305,9 +334,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowCloseCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setRefreshCallback(callback: WindowRefreshCallback?) {
+	actual fun setRefreshCallback(callback: WindowRefreshCallback?): WindowRefreshCallback? {
+		val previous = windowRefreshCallback
+		windowRefreshCallback = callback
 		if (callback != null) {
 			glfwSetWindowRefreshCallback(ptr) {
 				callback(this)
@@ -315,9 +347,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowRefreshCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setFocusCallback(callback: WindowFocusCallback?) {
+	actual fun setFocusCallback(callback: WindowFocusCallback?): WindowFocusCallback? {
+		val previous = windowFocusCallback
+		windowFocusCallback = callback
 		if (callback != null) {
 			glfwSetWindowFocusCallback(ptr) { _, focused ->
 				callback(this, focused)
@@ -325,9 +360,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowFocusCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setIconifyCallback(callback: WindowIconifyCallback?) {
+	actual fun setIconifyCallback(callback: WindowIconifyCallback?): WindowIconifyCallback? {
+		val previous = windowIconifyCallback
+		windowIconifyCallback = callback
 		if (callback != null) {
 			glfwSetWindowIconifyCallback(ptr) { _, focused ->
 				callback(this, focused)
@@ -335,9 +373,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowIconifyCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setMaximizeCallback(callback: WindowMaximizeCallback?) {
+	actual fun setMaximizeCallback(callback: WindowMaximizeCallback?): WindowMaximizeCallback? {
+		val previous = windowMaximizeCallback
+		windowMaximizeCallback = callback
 		if (callback != null) {
 			glfwSetWindowMaximizeCallback(ptr) { _, maximized ->
 				callback(this, maximized)
@@ -345,9 +386,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowMaximizeCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setContentScaleCallback(callback: WindowContentScaleCallback?) {
+	actual fun setContentScaleCallback(callback: WindowContentScaleCallback?): WindowContentScaleCallback? {
+		val previous = windowContentScaleCallback
+		windowContentScaleCallback = callback
 		if (callback != null) {
 			glfwSetWindowContentScaleCallback(ptr) { _, xscale, yscale ->
 				callback(this, xscale, yscale)
@@ -355,9 +399,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetWindowContentScaleCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setCursorEnterCallback(callback: CursorEnterCallback?) {
+	actual fun setCursorEnterCallback(callback: CursorEnterCallback?): CursorEnterCallback? {
+		val previous = cursorEnterCallback
+		cursorEnterCallback = callback
 		if (callback != null) {
 			glfwSetCursorEnterCallback(ptr) { _, focused ->
 				callback(this, focused)
@@ -365,9 +412,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetCursorEnterCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setScrollCallback(callback: ScrollCallback?) {
+	actual fun setScrollCallback(callback: ScrollCallback?): ScrollCallback? {
+		val previous = scrollCallback
+		scrollCallback = callback
 		if (callback != null) {
 			glfwSetScrollCallback(ptr) { _, x, y ->
 				callback(this, x, y)
@@ -375,9 +425,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetScrollCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setCursorPosCallback(callback: CursorPosCallback?) {
+	actual fun setCursorPosCallback(callback: CursorPosCallback?): CursorPosCallback? {
+		val previous = cursorPosCallback
+		cursorPosCallback = callback
 		if (callback != null) {
 			glfwSetCursorPosCallback(ptr) { _, x, y ->
 				callback(this, x, y)
@@ -385,9 +438,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetCursorPosCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setDropCallback(callback: DropCallback?) {
+	actual fun setDropCallback(callback: DropCallback?): DropCallback? {
+		val previous = dropCallback
+		dropCallback = callback
 		if (callback != null) {
 			glfwSetDropCallback(ptr) { _, count, names ->
 				val pNames = PointerBuffer.create(names, count)
@@ -396,9 +452,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetDropCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setKeyCallback(callback: KeyCallback?) {
+	actual fun setKeyCallback(callback: KeyCallback?): KeyCallback? {
+		val previous = keyCallback
+		keyCallback = callback
 		if (callback != null) {
 			glfwSetKeyCallback(ptr) { _, key, scancode, action, mods ->
 				callback(this, KeyboardKey.from(key), scancode, Action.from(action), Flag(mods))
@@ -406,9 +465,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetKeyCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setMouseButtonCallback(callback: MouseButtonCallback?) {
+	actual fun setMouseButtonCallback(callback: MouseButtonCallback?): MouseButtonCallback? {
+		val previous = mouseButtonCallback
+		mouseButtonCallback = callback
 		if (callback != null) {
 			glfwSetMouseButtonCallback(ptr) { _, button, action, mods ->
 				callback(this, MouseButton.from(button), Action.from(action), Flag(mods))
@@ -416,9 +478,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetMouseButtonCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setCharCallback(callback: CharCallback?) {
+	actual fun setCharCallback(callback: CharCallback?): CharCallback? {
+		val previous = charCallback
+		charCallback = callback
 		if (callback != null) {
 			glfwSetCharCallback(ptr) { _, codepoint ->
 				callback(this, codepoint.toUInt())
@@ -426,9 +491,12 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetCharCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
-	actual fun setCharModsCallback(callback: CharModsCallback?) {
+	actual fun setCharModsCallback(callback: CharModsCallback?): CharModsCallback? {
+		val previous = charModsCallback
+		charModsCallback = callback
 		if (callback != null) {
 			glfwSetCharModsCallback(ptr) { _, codepoint, mods ->
 				callback(this, codepoint.toUInt(), Flag(mods))
@@ -436,6 +504,7 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		} else {
 			glfwSetCharModsCallback(ptr, null)
 		}?.free()
+		return previous
 	}
 
 	actual fun swapBuffers() {

--- a/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Window.kt
@@ -339,7 +339,11 @@ actual class Window @PublishedApi internal constructor(val ptr: CPointer<GLFWwin
 		propSetter(callback)
 
 		if (callback != null) {
-			realSetter(ptr, getCFunction())
+			// only set the native callback if there was no callback set,
+			// since the native callback has a reference to the property
+			if (previous == null) {
+				realSetter(ptr, getCFunction())
+			}
 		} else {
 			realSetter(ptr, null)
 		}

--- a/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Window.kt
@@ -335,115 +335,140 @@ actual class Window @PublishedApi internal constructor(val ptr: CPointer<GLFWwin
 		}
 	}
 
-	actual fun setPosCallback(callback: WindowPosCallback?) {
+	actual fun setPosCallback(callback: WindowPosCallback?): WindowPosCallback? {
+		val previous = windowPosCallback
 		setCallback(callback, { windowPosCallback }, { windowPosCallback = it }, ::glfwSetWindowPosCallback) {
 			staticCFunction { window, width, height ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowPosCallback?.invoke(context, width, height)
 			}
 		}
+		return previous
 	}
 
-	actual fun setSizeCallback(callback: WindowSizeCallback?) {
+	actual fun setSizeCallback(callback: WindowSizeCallback?): WindowSizeCallback? {
+		val previous = windowSizeCallback
 		setCallback(callback, { windowSizeCallback }, { windowSizeCallback = it }, ::glfwSetWindowSizeCallback) {
 			staticCFunction { window, width, height ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowSizeCallback?.invoke(context, width, height)
 			}
 		}
+		return previous
 	}
 
-	actual fun setCloseCallback(callback: WindowCloseCallback?) {
+	actual fun setCloseCallback(callback: WindowCloseCallback?): WindowCloseCallback? {
+		val previous = windowCloseCallback
 		setCallback(callback, { windowCloseCallback }, { windowCloseCallback = it }, ::glfwSetWindowCloseCallback) {
 			staticCFunction { window ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowCloseCallback?.invoke(context)
 			}
 		}
+		return previous
 	}
 
-	actual fun setRefreshCallback(callback: WindowRefreshCallback?) {
+	actual fun setRefreshCallback(callback: WindowRefreshCallback?): WindowRefreshCallback? {
+		val previous = windowRefreshCallback
 		setCallback(callback, { windowRefreshCallback }, { windowRefreshCallback = it }, ::glfwSetWindowRefreshCallback) {
 			staticCFunction { window ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowRefreshCallback?.invoke(context)
 			}
 		}
+		return previous
 	}
 
-	actual fun setFocusCallback(callback: WindowFocusCallback?) {
+	actual fun setFocusCallback(callback: WindowFocusCallback?): WindowFocusCallback? {
+		val previous = windowFocusCallback
 		setCallback(callback, { windowFocusCallback }, { windowFocusCallback = it }, ::glfwSetWindowFocusCallback) {
 			staticCFunction { window, focused ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowFocusCallback?.invoke(context, focused == GLFW_TRUE)
 			}
 		}
+		return previous
 	}
 
-	actual fun setIconifyCallback(callback: WindowIconifyCallback?) {
+	actual fun setIconifyCallback(callback: WindowIconifyCallback?): WindowIconifyCallback? {
+		val previous = windowIconifyCallback
 		setCallback(callback, { windowIconifyCallback }, { windowIconifyCallback = it }, ::glfwSetWindowIconifyCallback) {
 			staticCFunction { window, iconify ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowIconifyCallback?.invoke(context, iconify == GLFW_TRUE)
 			}
 		}
+		return previous
 	}
 
-	actual fun setMaximizeCallback(callback: WindowMaximizeCallback?) {
+	actual fun setMaximizeCallback(callback: WindowMaximizeCallback?): WindowMaximizeCallback? {
+		val previous = windowMaximizeCallback
 		setCallback(callback, { windowMaximizeCallback }, { windowMaximizeCallback = it }, ::glfwSetWindowMaximizeCallback) {
 			staticCFunction { window, maximize ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowMaximizeCallback?.invoke(context, maximize == GLFW_TRUE)
 			}
 		}
+		return previous
 	}
 
-	actual fun setContentScaleCallback(callback: WindowContentScaleCallback?) {
+	actual fun setContentScaleCallback(callback: WindowContentScaleCallback?): WindowContentScaleCallback? {
+		val previous = windowContentScaleCallback
 		setCallback(callback, { windowContentScaleCallback }, { windowContentScaleCallback = it }, ::glfwSetWindowContentScaleCallback) {
 			staticCFunction { window, x, y ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.windowContentScaleCallback?.invoke(context, x, y)
 			}
 		}
+		return previous
 	}
 
-	actual fun setCursorEnterCallback(callback: CursorEnterCallback?) {
+	actual fun setCursorEnterCallback(callback: CursorEnterCallback?): CursorEnterCallback? {
+		val previous = cursorEnterCallback
 		setCallback(callback, { cursorEnterCallback }, { cursorEnterCallback = it }, ::glfwSetCursorEnterCallback) {
 			staticCFunction { window, entered ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.cursorEnterCallback?.invoke(context, entered == GLFW_TRUE)
 			}
 		}
+		return previous
 	}
 
-	actual fun setScrollCallback(callback: ScrollCallback?) {
+	actual fun setScrollCallback(callback: ScrollCallback?): ScrollCallback? {
+		val previous = scrollCallback
 		setCallback(callback, { scrollCallback }, { scrollCallback = it }, ::glfwSetScrollCallback) {
 			staticCFunction { window, x, y ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.scrollCallback?.invoke(context, x, y)
 			}
 		}
+		return previous
 	}
 
-	actual fun setCursorPosCallback(callback: CursorPosCallback?) {
+	actual fun setCursorPosCallback(callback: CursorPosCallback?): CursorPosCallback? {
+		val previous = cursorPosCallback
 		setCallback(callback, { cursorPosCallback }, { cursorPosCallback = it }, ::glfwSetCursorPosCallback) {
 			staticCFunction { window, width, height ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.cursorPosCallback?.invoke(context, width, height)
 			}
 		}
+		return previous
 	}
 
-	actual fun setFrameBufferCallback(callback: FrameBufferCallback?) {
+	actual fun setFrameBufferCallback(callback: FrameBufferCallback?): FrameBufferCallback? {
+		val previous = frameBufferCallback
 		setCallback(callback, { frameBufferCallback }, { frameBufferCallback = it }, ::glfwSetFramebufferSizeCallback) {
 			staticCFunction { window, width, height ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.frameBufferCallback?.invoke(context, width, height)
 			}
 		}
+		return previous
 	}
 
-	actual fun setDropCallback(callback: DropCallback?) {
+	actual fun setDropCallback(callback: DropCallback?): DropCallback? {
+		val previous = dropCallback
 		setCallback(callback, { dropCallback }, { dropCallback = it }, ::glfwSetDropCallback) {
 			staticCFunction { window, count, names ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
@@ -451,9 +476,11 @@ actual class Window @PublishedApi internal constructor(val ptr: CPointer<GLFWwin
 				context.dropCallback?.invoke(context, Array(count) { names[it]!!.toKString() })
 			}
 		}
+		return previous
 	}
 
-	actual fun setKeyCallback(callback: KeyCallback?) {
+	actual fun setKeyCallback(callback: KeyCallback?): KeyCallback? {
+		val previous = keyCallback
 		setCallback(callback, { keyCallback }, { keyCallback = it }, ::glfwSetKeyCallback) {
 			staticCFunction { window, key, scancode, action, mods ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
@@ -462,9 +489,11 @@ actual class Window @PublishedApi internal constructor(val ptr: CPointer<GLFWwin
 				)
 			}
 		}
+		return previous
 	}
 
-	actual fun setMouseButtonCallback(callback: MouseButtonCallback?) {
+	actual fun setMouseButtonCallback(callback: MouseButtonCallback?): MouseButtonCallback? {
+		val previous = mouseButtonCallback
 		setCallback(callback, { mouseButtonCallback }, { mouseButtonCallback = it }, ::glfwSetMouseButtonCallback) {
 			staticCFunction { window, button, action, mods ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
@@ -473,24 +502,29 @@ actual class Window @PublishedApi internal constructor(val ptr: CPointer<GLFWwin
 				)
 			}
 		}
+		return previous
 	}
 
-	actual fun setCharCallback(callback: CharCallback?) {
+	actual fun setCharCallback(callback: CharCallback?): CharCallback? {
+		val previous = charCallback
 		setCallback(callback, { charCallback }, { charCallback = it }, ::glfwSetCharCallback) {
 			staticCFunction { window, codepoint ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.charCallback?.invoke(context, codepoint)
 			}
 		}
+		return previous
 	}
 
-	actual fun setCharModsCallback(callback: CharModsCallback?) {
+	actual fun setCharModsCallback(callback: CharModsCallback?): CharModsCallback? {
+		val previous = charModsCallback
 		setCallback(callback, { charModsCallback }, { charModsCallback = it }, ::glfwSetCharModsCallback) {
 			staticCFunction { window, codepoint, mods ->
 				val context = glfwGetWindowUserPointer(window)!!.asStableRef<Window>().get()
 				context.charModsCallback?.invoke(context, codepoint, Flag(mods))
 			}
 		}
+		return previous
 	}
 
 	override fun close() {


### PR DESCRIPTION
This is relevant and important because it directly affects the ability of the imgui glfw implementation to function. The C++ version takes the returned callbacks and stores them to be called alongside the callbacks it installs. Not returning the previous callbacks results in two possible scenarios:

1. `ImGuiGlfw` is initialized **with** callbacks and mouse events are eaten by ImGui, disabling mouse event processing by the application proper.
2. `ImGuiGlfw` is initialized **without** callbacks and key events are not processed by ImGui, preventing text entry in ImGui.

This is the first of two updates to fix the issue. Part two will actually utilize the `prev...` callback references in `ImGuiGLFW` and set them to the proper values, but it understandably depends on this change.

I've already made the changes and tested them locally by publishing to the local maven repo. Please let me know if I've missed anything in my attempts to fix this.