### PR TITLE
add return values to global callback setters

### DIFF
--- a/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -32,9 +32,9 @@ expect object Glfw {
 	fun init(): Boolean
 	fun terminate()
 
-	fun setErrorCallback(callback: ErrorCallback? = null)
-	fun setJoystickCallback(callback: JoystickCallback? = null)
-	fun setMonitorCallback(callback: MonitorCallback? = null)
+	fun setErrorCallback(callback: ErrorCallback? = null): ErrorCallback?
+	fun setJoystickCallback(callback: JoystickCallback? = null): JoystickCallback?
+	fun setMonitorCallback(callback: MonitorCallback? = null): MonitorCallback?
 
 	fun pollEvents()
 	fun waitEvents()

--- a/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -15,7 +15,6 @@
  */
 package com.kgl.glfw
 
-import com.sun.jdi.request.*
 import org.lwjgl.PointerBuffer
 import org.lwjgl.glfw.GLFW.*
 import org.lwjgl.system.MemoryStack

--- a/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -15,6 +15,7 @@
  */
 package com.kgl.glfw
 
+import com.sun.jdi.request.*
 import org.lwjgl.PointerBuffer
 import org.lwjgl.glfw.GLFW.*
 import org.lwjgl.system.MemoryStack
@@ -63,34 +64,59 @@ actual object Glfw {
 		glfwTerminate()
 	}
 
-	actual fun setErrorCallback(callback: ErrorCallback?) {
+	private var errorCallback: ErrorCallback? = null
+	private var joystickCallback: JoystickCallback? = null
+	private var monitorCallback: MonitorCallback? = null
+
+	actual fun setErrorCallback(callback: ErrorCallback?): ErrorCallback? {
+		val previous = errorCallback
+		errorCallback = callback
+
 		if (callback != null) {
-			glfwSetErrorCallback { error, description ->
-				callback(error, MemoryUtil.memUTF8(description))
+			if (previous == null) {
+				glfwSetErrorCallback { error, description ->
+					errorCallback?.invoke(error, MemoryUtil.memUTF8(description))
+				}?.free()
 			}
 		} else {
-			glfwSetErrorCallback(null)
-		}?.free()
+			glfwSetErrorCallback(null)?.free()
+		}
+
+		return previous
 	}
 
-	actual fun setJoystickCallback(callback: JoystickCallback?) {
+	actual fun setJoystickCallback(callback: JoystickCallback?): JoystickCallback? {
+		val previous = joystickCallback
+		joystickCallback = callback
+
 		if (callback != null) {
-			glfwSetJoystickCallback { jid, event ->
-				callback(Joystick.values()[jid], event == GLFW_CONNECTED)
+			if (previous == null) {
+				glfwSetJoystickCallback { jid, event ->
+					joystickCallback?.invoke(Joystick.values()[jid], event == GLFW_CONNECTED)
+				}?.free()
 			}
 		} else {
-			glfwSetJoystickCallback(null)
-		}?.free()
+			glfwSetJoystickCallback(null)?.free()
+		}
+
+		return previous
 	}
 
-	actual fun setMonitorCallback(callback: MonitorCallback?) {
+	actual fun setMonitorCallback(callback: MonitorCallback?): MonitorCallback? {
+		val previous = monitorCallback
+		monitorCallback = callback
+
 		if (callback != null) {
-			glfwSetMonitorCallback { monitor, event ->
-				callback(Monitor(monitor), event == GLFW_CONNECTED)
+			if (previous == null) {
+				glfwSetMonitorCallback { monitor, event ->
+					monitorCallback?.invoke(Monitor(monitor), event == GLFW_CONNECTED)
+				}?.free()
 			}
 		} else {
-			glfwSetMonitorCallback(null)
-		}?.free()
+			glfwSetMonitorCallback(null)?.free()
+		}
+
+		return previous
 	}
 
 	actual fun pollEvents() {

--- a/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -81,49 +81,55 @@ actual object Glfw {
 	private var joystickCallback: JoystickCallback? = null
 	private var monitorCallback: MonitorCallback? = null
 
-	actual fun setErrorCallback(callback: ErrorCallback?) {
-		val wasNotPreviouslySet = errorCallback == null
+	actual fun setErrorCallback(callback: ErrorCallback?): ErrorCallback? {
+		val previous = errorCallback
 		errorCallback = callback
 
 		if (callback != null) {
-			if (wasNotPreviouslySet) {
+			if (previous == null) {
 				glfwSetErrorCallback(staticCFunction { error, description ->
-					Glfw.errorCallback?.invoke(error, description!!.toKString())
+					errorCallback?.invoke(error, description!!.toKString())
 				})
 			}
 		} else {
 			glfwSetErrorCallback(null)
 		}
+
+		return previous
 	}
 
-	actual fun setJoystickCallback(callback: JoystickCallback?) {
-		val wasNotPreviouslySet = joystickCallback == null
+	actual fun setJoystickCallback(callback: JoystickCallback?): JoystickCallback? {
+		val previous = joystickCallback
 		joystickCallback = callback
 
 		if (callback != null) {
-			if (wasNotPreviouslySet) {
+			if (previous == null) {
 				glfwSetJoystickCallback(staticCFunction { jid, event ->
-					Glfw.joystickCallback?.invoke(Joystick.values()[jid], event == GLFW_CONNECTED)
+					joystickCallback?.invoke(Joystick.values()[jid], event == GLFW_CONNECTED)
 				})
 			}
 		} else {
 			glfwSetJoystickCallback(null)
 		}
+
+		return previous
 	}
 
-	actual fun setMonitorCallback(callback: MonitorCallback?) {
-		val wasNotPreviouslySet = monitorCallback == null
+	actual fun setMonitorCallback(callback: MonitorCallback?): MonitorCallback? {
+		val previous = monitorCallback
 		monitorCallback = callback
 
 		if (callback != null) {
-			if (wasNotPreviouslySet) {
+			if (previous == null) {
 				glfwSetMonitorCallback(staticCFunction { monitor, event ->
-					Glfw.monitorCallback?.invoke(Monitor(monitor!!), event == GLFW_CONNECTED)
+					monitorCallback?.invoke(Monitor(monitor!!), event == GLFW_CONNECTED)
 				})
 			}
 		} else {
 			glfwSetMonitorCallback(null)
 		}
+
+		return previous
 	}
 
 	actual fun pollEvents() {


### PR DESCRIPTION
`Glfw.setErrorCallback`, `Glfw.setJoystickCallback`, and `Glfw.setMonitorCallback` (the last one is needed for imgui-docking) were not returning the previous callbacks. I missed those with the last fix, and this time I double checked that all functions named `set…Callback` have a return type.