### PR TITLE
Input struct pNext DSL

### DIFF
--- a/buildSrc/src/main/kotlin/codegen/Types.kt
+++ b/buildSrc/src/main/kotlin/codegen/Types.kt
@@ -36,6 +36,7 @@ object KtxC {
 	val POINTED = MemberName("kotlinx.cinterop", "pointed")
 	val PTR = MemberName("kotlinx.cinterop", "ptr")
 	val TO_KSTRING = MemberName("kotlinx.cinterop", "toKString")
+	val CONVERT = MemberName("kotlinx.cinterop", "convert")
 	val ALLOC = MemberName("kotlinx.cinterop", "alloc")
 	val VALUE = MemberName("kotlinx.cinterop", "value")
 	val CSTR = MemberName("kotlinx.cinterop", "cstr")

--- a/buildSrc/src/main/kotlin/codegen/vulkan/GenerateVulkan.kt
+++ b/buildSrc/src/main/kotlin/codegen/vulkan/GenerateVulkan.kt
@@ -111,6 +111,15 @@ open class GenerateVulkan : DefaultTask() {
 								lambdaParam("SubmitInfoBuilder", withDefault = true)
 						)
 				),
+				"VkPresentInfoKHR" to listOf(
+						listOf(
+								param("swapchains", COLLECTION.parameterizedBy(
+										PAIR.parameterizedBy(handle("SwapchainKHR"), U_INT)
+								)),
+								param("waitSemaphores", COLLECTION.parameterizedBy(handle("Semaphore")).copy(nullable = true)),
+								lambdaParam("PresentInfoKHRBuilder", withDefault = true)
+						)
+				),
 				"VkSubpassDescription" to listOf(
 						listOf(
 								param(
@@ -144,6 +153,30 @@ open class GenerateVulkan : DefaultTask() {
 								param("queueFamilyIndex", U_INT),
 								param("queuePriorities", FLOAT, KModifier.VARARG),
 								lambdaParam("DeviceQueueCreateInfoBuilder", true)
+						)
+				),
+				"VkDebugUtilsMessengerCreateInfoEXT" to listOf(
+						listOf(
+								lambdaParam("DebugUtilsMessengerCreateInfoEXTBuilder")
+						)
+				),
+				"VkDebugReportCallbackCreateInfoEXT" to listOf(
+						listOf(
+								lambdaParam("DebugReportCallbackCreateInfoEXTBuilder")
+						)
+				),
+				"VkShaderModuleCreateInfo" to listOf(
+						listOf(
+								param("code", U_BYTE_ARRAY),
+								lambdaParam("ShaderModuleCreateInfoBuilder", true)
+						)
+				),
+				"VkObjectTableCreateInfoNVX" to listOf(
+						listOf(
+								param("objectEntryTypes", COLLECTION.parameterizedBy(ClassName("com.kgl.vulkan.enums", "ObjectEntryTypeNVX"))),
+								param("objectEntryCounts", U_INT_ARRAY),
+								param("objectEntryUsageFlags", COLLECTION.parameterizedBy(VK_FLAG.parameterizedBy(ClassName("com.kgl.vulkan.enums", "ObjectEntryUsageNVX")))),
+								lambdaParam("ObjectTableCreateInfoNVXBuilder", true)
 						)
 				)
 		)

--- a/buildSrc/src/main/kotlin/codegen/vulkan/GenerateVulkan.kt
+++ b/buildSrc/src/main/kotlin/codegen/vulkan/GenerateVulkan.kt
@@ -1947,6 +1947,12 @@ open class GenerateVulkan : DefaultTask() {
 								addStatement("val builder = %T(subTarget)", structBuilderClass)
 								addStatement(passedParams.joinToString(", ", prefix = "builder.init(", postfix = ")") { it.name })
 								if (hasLambda) addStatement("builder.apply(block)")
+
+								if (it == Platform.JVM && struct.structExtends.size > 1) {
+									addAnnotation(AnnotationSpec.builder(JvmName::class)
+											.addMember("%S", "${extendee}_${struct.name}")
+											.build())
+								}
 							}
 						}
 						pNextFileCommon.addFunction(function.common)

--- a/buildSrc/src/main/kotlin/codegen/vulkan/GenerateVulkan.kt
+++ b/buildSrc/src/main/kotlin/codegen/vulkan/GenerateVulkan.kt
@@ -1473,7 +1473,7 @@ open class GenerateVulkan : DefaultTask() {
 										} else {
 											if (isOptional) beginControlFlow("if ($memberNameKt != null)")
 											addStatement("target.${member.name} = $memberNameKt.pointer")
-											addStatement("target.${member.len[0]} = $memberNameKt.size.toULong()")
+											addStatement("target.${member.len[0]} = $memberNameKt.size.%M()", KtxC.CONVERT)
 											if (isOptional) {
 												nextControlFlow("else")
 												addStatement("target.${member.name} = null")

--- a/buildSrc/src/main/kotlin/codegen/vulkan/Types.kt
+++ b/buildSrc/src/main/kotlin/codegen/vulkan/Types.kt
@@ -26,6 +26,7 @@ val VK_HANDLE_JVM = ClassName("com.kgl.vulkan.utils", "VkHandleJVM")
 val VK_HANDLE_NATIVE = ClassName("com.kgl.vulkan.utils", "VkHandleNative")
 val VK_VERSION = ClassName("com.kgl.vulkan.utils", "VkVersion")
 val STRUCT_MARKER = ClassName("com.kgl.vulkan.utils", "StructMarker")
+val NEXT = ClassName("com.kgl.vulkan.utils", "Next")
 
 val BASE_OUT_STRUCTURE = ClassName("com.kgl.vulkan.structs", "BaseOutStructure")
 

--- a/buildSrc/src/main/resources/vk_hidden_entries.json
+++ b/buildSrc/src/main/resources/vk_hidden_entries.json
@@ -5,5 +5,8 @@
   "VkPhysicalDeviceMemoryProperties.memoryHeapCount",
   "VkPhysicalDeviceGroupProperties.physicalDeviceCount",
   "VkDescriptorSetLayoutBinding",
-  "VkShaderModuleCreateInfo"
+  "VkShaderModuleCreateInfo",
+  "VkImageDrmFormatModifierExplicitCreateInfoEXT",
+  "VkSubresourceLayout",
+  "VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
 ]

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/DebugReportCallbackCreateInfoEXTBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/DebugReportCallbackCreateInfoEXTBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.DebugReportEXT
 import com.kgl.vulkan.enums.DebugReportObjectTypeEXT
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
@@ -35,6 +36,8 @@ expect class DebugReportCallbackCreateInfoEXTBuilder {
 	var flags: VkFlag<DebugReportEXT>?
 
 	fun callback(callback: DebugReportCallbackEXT)
+
+	fun next(block: Next<DebugReportCallbackCreateInfoEXTBuilder>.() -> Unit)
 
 	internal fun init()
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/DebugUtilsMessengerCreateInfoEXTBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/DebugUtilsMessengerCreateInfoEXTBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DebugUtilsMessageSeverityEXT
 import com.kgl.vulkan.enums.DebugUtilsMessageTypeEXT
 import com.kgl.vulkan.structs.DebugUtilsMessengerCallbackDataEXT
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
@@ -34,6 +35,8 @@ expect class DebugUtilsMessengerCreateInfoEXTBuilder {
 	var messageType: VkFlag<DebugUtilsMessageTypeEXT>?
 
 	fun userCallback(callback: DebugUtilsMessengerCallbackEXT)
+
+	fun next(block: Next<DebugUtilsMessengerCreateInfoEXTBuilder>.() -> Unit)
 
 	internal fun init()
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/DescriptorSetLayoutBindingBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/DescriptorSetLayoutBindingBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DescriptorType
 import com.kgl.vulkan.enums.ShaderStage
 import com.kgl.vulkan.handles.Sampler
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
@@ -28,6 +29,8 @@ expect class DescriptorSetLayoutBindingBuilder {
 	var descriptorType: DescriptorType?
 
 	var stageFlags: VkFlag<ShaderStage>?
+
+	fun next(block: Next<DescriptorSetLayoutBindingBuilder>.() -> Unit)
 
 	internal fun init(immutableSamplers: Collection<Sampler>)
 

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/ObjectTableCreateInfoNVXBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/ObjectTableCreateInfoNVXBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.ObjectEntryTypeNVX
 import com.kgl.vulkan.enums.ObjectEntryUsageNVX
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
@@ -31,6 +32,8 @@ expect class ObjectTableCreateInfoNVXBuilder {
 	var maxSampledImagesPerDescriptor: UInt
 
 	var maxPipelineLayouts: UInt
+
+	fun next(block: Next<ObjectTableCreateInfoNVXBuilder>.() -> Unit)
 
 	internal fun init(
 			objectEntryTypes: Collection<ObjectEntryTypeNVX>,

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/PresentInfoKHRBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/PresentInfoKHRBuilder.kt
@@ -17,9 +17,12 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.handles.Semaphore
 import com.kgl.vulkan.handles.SwapchainKHR
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 
 @StructMarker
 expect class PresentInfoKHRBuilder {
+	fun next(block: Next<PresentInfoKHRBuilder>.() -> Unit)
+
 	internal fun init(swapchains: Collection<Pair<SwapchainKHR, UInt>>, waitSemaphores: Collection<Semaphore>?)
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/ShaderModuleCreateInfoBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/ShaderModuleCreateInfoBuilder.kt
@@ -15,9 +15,12 @@
  */
 package com.kgl.vulkan.dsls
 
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 
 @StructMarker
 expect class ShaderModuleCreateInfoBuilder {
+	fun next(block: Next<ShaderModuleCreateInfoBuilder>.() -> Unit)
+
 	internal fun init(code: UByteArray)
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/SubmitInfoBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/SubmitInfoBuilder.kt
@@ -18,11 +18,14 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.PipelineStage
 import com.kgl.vulkan.handles.CommandBuffer
 import com.kgl.vulkan.handles.Semaphore
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
 @StructMarker
 expect class SubmitInfoBuilder {
+	fun next(block: Next<SubmitInfoBuilder>.() -> Unit)
+
 	internal fun init(
 			waitSemaphores: Collection<Pair<Semaphore, VkFlag<PipelineStage>>>?,
 			commandBuffers: Collection<CommandBuffer>?,

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/SubpassDescription2KHRBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/SubpassDescription2KHRBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.PipelineBindPoint
 import com.kgl.vulkan.enums.SubpassDescription
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
@@ -35,6 +36,8 @@ expect class SubpassDescription2KHRBuilder {
 	fun resolveAttachments(block: AttachmentReference2KHRsBuilder.() -> Unit)
 
 	fun depthStencilAttachment(block: AttachmentReference2KHRBuilder.() -> Unit = {})
+
+	fun next(block: Next<SubpassDescription2KHRBuilder>.() -> Unit)
 
 	internal fun init(preserveAttachments: UIntArray)
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/SubpassDescriptionBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/SubpassDescriptionBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.PipelineBindPoint
 import com.kgl.vulkan.enums.SubpassDescription
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 import com.kgl.vulkan.utils.VkFlag
 
@@ -33,6 +34,8 @@ expect class SubpassDescriptionBuilder {
 	fun resolveAttachments(block: AttachmentReferencesBuilder.() -> Unit)
 
 	fun depthStencilAttachment(block: AttachmentReferenceBuilder.() -> Unit = {})
+
+	fun next(block: Next<SubpassDescriptionBuilder>.() -> Unit)
 
 	internal fun init(preserveAttachments: UIntArray?)
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/WriteDescriptorSetBuilder.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/dsls/WriteDescriptorSetBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DescriptorType
 import com.kgl.vulkan.handles.BufferView
 import com.kgl.vulkan.handles.DescriptorSet
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.StructMarker
 
 @StructMarker
@@ -31,6 +32,8 @@ expect class WriteDescriptorSetBuilder {
 	fun imageInfo(block: DescriptorImageInfosBuilder.() -> Unit)
 
 	fun bufferInfo(block: DescriptorBufferInfosBuilder.() -> Unit)
+
+	fun next(block: Next<WriteDescriptorSetBuilder>.() -> Unit)
 
 	internal fun init(dstSet: DescriptorSet, texelBufferView: Collection<BufferView>?)
 }

--- a/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/utils/Next.kt
+++ b/kgl-vulkan/src/commonMain/kotlin/com/kgl/vulkan/utils/Next.kt
@@ -1,0 +1,5 @@
+package com.kgl.vulkan.utils
+
+// TODO: Make this an inline class
+@StructMarker
+class Next<T>(internal val targetBuilder: T)

--- a/kgl-vulkan/src/commonTest/kotlin/com/kgl/vulkan/DslTests.kt
+++ b/kgl-vulkan/src/commonTest/kotlin/com/kgl/vulkan/DslTests.kt
@@ -71,12 +71,21 @@ class DslTests {
 			next {
 				ValidationFlagsEXT(listOf(ValidationCheckEXT.ALL_EXT, ValidationCheckEXT.SHADERS_EXT))
 
-				// DebugReportCallbackCreateInfoEXT {
-				//     flags = DebugReportFlagBitsEXT.WARNING or DebugReportFlagBitsEXT.ERROR
-				//     callback { _, _, _, _, _, _, message ->
-				//         println("Debug Message: $message")
-				//     }
-				// }
+				DebugReportCallbackCreateInfoEXT {
+				    flags = DebugReportEXT.WARNING_BIT_EXT or DebugReportEXT.ERROR_BIT_EXT
+				    callback { _, _, _, _, _, _, message ->
+				        println("Debug Message: $message")
+				    }
+				}
+
+				DebugUtilsMessengerCreateInfoEXT {
+					messageType = DebugUtilsMessageTypeEXT.GENERAL
+					messageSeverity = DebugUtilsMessageSeverityEXT.ERROR
+
+					userCallback { messageSeverity, messageTypes, callbackData ->
+						println("$messageSeverity $messageTypes $callbackData")
+					}
+				}
 			}
 		}
 	}

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/DebugReportCallbackCreateInfoEXTBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/DebugReportCallbackCreateInfoEXTBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.DebugReportEXT
 import com.kgl.vulkan.enums.DebugReportObjectTypeEXT
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.vulkan.EXTDebugReport
@@ -42,6 +43,10 @@ actual class DebugReportCallbackCreateInfoEXTBuilder(internal val target: VkDebu
 			)
 			VK10.VK_FALSE
 		}
+	}
+
+	actual fun next(block: Next<DebugReportCallbackCreateInfoEXTBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init() {

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/DebugUtilsMessengerCreateInfoEXTBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/DebugUtilsMessengerCreateInfoEXTBuilder.kt
@@ -19,6 +19,7 @@ import com.kgl.vulkan.enums.DebugUtilsMessageSeverityEXT
 import com.kgl.vulkan.enums.DebugUtilsMessageTypeEXT
 import com.kgl.vulkan.structs.DebugUtilsMessengerCallbackDataEXT
 import com.kgl.vulkan.structs.from
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import org.lwjgl.vulkan.EXTDebugUtils.VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT
 import org.lwjgl.vulkan.VK10.VK_FALSE
@@ -48,6 +49,10 @@ actual class DebugUtilsMessengerCreateInfoEXTBuilder(internal val target: VkDebu
 			)
 			VK_FALSE
 		}
+	}
+
+	actual fun next(block: Next<DebugUtilsMessengerCreateInfoEXTBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init() {

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/DescriptorSetLayoutBindingBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/DescriptorSetLayoutBindingBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DescriptorType
 import com.kgl.vulkan.enums.ShaderStage
 import com.kgl.vulkan.handles.Sampler
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.toVkType
 import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding
@@ -40,6 +41,10 @@ actual class DescriptorSetLayoutBindingBuilder(internal val target: VkDescriptor
 		set(value) {
 			target.stageFlags(value.toVkType())
 		}
+
+	actual fun next(block: Next<DescriptorSetLayoutBindingBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
 
 	internal actual fun init(immutableSamplers: Collection<Sampler>) {
 		target.pImmutableSamplers(immutableSamplers.toVkType())

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/ObjectTableCreateInfoNVXBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/ObjectTableCreateInfoNVXBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.ObjectEntryTypeNVX
 import com.kgl.vulkan.enums.ObjectEntryUsageNVX
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.toVkType
 import org.lwjgl.vulkan.NVXDeviceGeneratedCommands
@@ -52,6 +53,10 @@ actual class ObjectTableCreateInfoNVXBuilder(internal val target: VkObjectTableC
 		set(value) {
 			target.maxPipelineLayouts(value.toVkType())
 		}
+
+	actual fun next(block: Next<ObjectTableCreateInfoNVXBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
 
 	internal actual fun init(
 			objectEntryTypes: Collection<ObjectEntryTypeNVX>,

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/PresentInfoKHRBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/PresentInfoKHRBuilder.kt
@@ -17,11 +17,16 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.handles.Semaphore
 import com.kgl.vulkan.handles.SwapchainKHR
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.toVkType
 import org.lwjgl.vulkan.KHRSwapchain
 import org.lwjgl.vulkan.VkPresentInfoKHR
 
 actual class PresentInfoKHRBuilder(internal val target: VkPresentInfoKHR) {
+	actual fun next(block: Next<PresentInfoKHRBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
+
 	internal actual fun init(swapchains: Collection<Pair<SwapchainKHR, UInt>>, waitSemaphores: Collection<Semaphore>?) {
 		target.sType(KHRSwapchain.VK_STRUCTURE_TYPE_PRESENT_INFO_KHR)
 		target.pNext(0)

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/ShaderModuleCreateInfoBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/ShaderModuleCreateInfoBuilder.kt
@@ -15,11 +15,16 @@
  */
 package com.kgl.vulkan.dsls
 
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.toVkType
 import org.lwjgl.vulkan.VK11
 import org.lwjgl.vulkan.VkShaderModuleCreateInfo
 
 actual class ShaderModuleCreateInfoBuilder(internal val target: VkShaderModuleCreateInfo) {
+	actual fun next(block: Next<ShaderModuleCreateInfoBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
+
 	internal actual fun init(code: UByteArray) {
 		target.sType(VK11.VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
 		target.pNext(0)

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/SubmitInfoBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/SubmitInfoBuilder.kt
@@ -18,12 +18,17 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.PipelineStage
 import com.kgl.vulkan.handles.CommandBuffer
 import com.kgl.vulkan.handles.Semaphore
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.toVkType
 import org.lwjgl.vulkan.VK11
 import org.lwjgl.vulkan.VkSubmitInfo
 
 actual class SubmitInfoBuilder(internal val target: VkSubmitInfo) {
+	actual fun next(block: Next<SubmitInfoBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
+
 	internal actual fun init(
 			waitSemaphores: Collection<Pair<Semaphore, VkFlag<PipelineStage>>>?,
 			commandBuffers: Collection<CommandBuffer>?,

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/SubpassDescription2KHRBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/SubpassDescription2KHRBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.PipelineBindPoint
 import com.kgl.vulkan.enums.SubpassDescription
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.mapToStackArray
 import com.kgl.vulkan.utils.toVkType
@@ -64,6 +65,10 @@ actual class SubpassDescription2KHRBuilder(internal val target: VkSubpassDescrip
 		val builder = AttachmentReference2KHRBuilder(subTarget)
 		builder.init()
 		builder.apply(block)
+	}
+
+	actual fun next(block: Next<SubpassDescription2KHRBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init(preserveAttachments: UIntArray) {

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/SubpassDescriptionBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/SubpassDescriptionBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.PipelineBindPoint
 import com.kgl.vulkan.enums.SubpassDescription
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.mapToStackArray
 import com.kgl.vulkan.utils.toVkType
@@ -58,6 +59,10 @@ actual class SubpassDescriptionBuilder(internal val target: VkSubpassDescription
 		val builder = AttachmentReferenceBuilder(subTarget)
 		builder.init()
 		builder.apply(block)
+	}
+
+	actual fun next(block: Next<SubpassDescriptionBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init(preserveAttachments: UIntArray?) {

--- a/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/WriteDescriptorSetBuilder.kt
+++ b/kgl-vulkan/src/jvmMain/kotlin/com/kgl/vulkan/dsls/WriteDescriptorSetBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DescriptorType
 import com.kgl.vulkan.handles.BufferView
 import com.kgl.vulkan.handles.DescriptorSet
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.mapToStackArray
 import com.kgl.vulkan.utils.toVkType
 import org.lwjgl.vulkan.VK11
@@ -52,6 +53,10 @@ actual class WriteDescriptorSetBuilder(internal val target: VkWriteDescriptorSet
 	actual fun bufferInfo(block: DescriptorBufferInfosBuilder.() -> Unit) {
 		val targets = DescriptorBufferInfosBuilder().apply(block).targets
 		target.pBufferInfo(targets.mapToStackArray(VkDescriptorBufferInfo::callocStack, ::DescriptorBufferInfoBuilder))
+	}
+
+	actual fun next(block: Next<WriteDescriptorSetBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init(dstSet: DescriptorSet, texelBufferView: Collection<BufferView>?) {

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/DebugReportCallbackCreateInfoEXTBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/DebugReportCallbackCreateInfoEXTBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.DebugReportEXT
 import com.kgl.vulkan.enums.DebugReportObjectTypeEXT
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import cvulkan.VK_FALSE
 import cvulkan.VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT
@@ -48,6 +49,10 @@ actual class DebugReportCallbackCreateInfoEXTBuilder(internal val target: VkDebu
 			)
 			VK_FALSE.toUInt()
 		}
+	}
+
+	actual fun next(block: Next<DebugReportCallbackCreateInfoEXTBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init() {

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/DebugUtilsMessengerCreateInfoEXTBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/DebugUtilsMessengerCreateInfoEXTBuilder.kt
@@ -19,6 +19,7 @@ import com.kgl.vulkan.enums.DebugUtilsMessageSeverityEXT
 import com.kgl.vulkan.enums.DebugUtilsMessageTypeEXT
 import com.kgl.vulkan.structs.DebugUtilsMessengerCallbackDataEXT
 import com.kgl.vulkan.structs.from
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import cvulkan.VK_FALSE
 import cvulkan.VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT
@@ -54,6 +55,10 @@ actual class DebugUtilsMessengerCreateInfoEXTBuilder(internal val target: VkDebu
 
 			VK_FALSE.toUInt()
 		}
+	}
+
+	actual fun next(block: Next<DebugUtilsMessengerCreateInfoEXTBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init() {

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/DescriptorSetLayoutBindingBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/DescriptorSetLayoutBindingBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DescriptorType
 import com.kgl.vulkan.enums.ShaderStage
 import com.kgl.vulkan.handles.Sampler
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.toVkType
 import cvulkan.VkDescriptorSetLayoutBinding
@@ -40,6 +41,10 @@ actual class DescriptorSetLayoutBindingBuilder(internal val target: VkDescriptor
 		set(value) {
 			target.stageFlags = value.toVkType()
 		}
+
+	actual fun next(block: Next<DescriptorSetLayoutBindingBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
 
 	internal actual fun init(immutableSamplers: Collection<Sampler>) {
 		target.pImmutableSamplers = immutableSamplers.toVkType()

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/ObjectTableCreateInfoNVXBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/ObjectTableCreateInfoNVXBuilder.kt
@@ -17,6 +17,7 @@ package com.kgl.vulkan.dsls
 
 import com.kgl.vulkan.enums.ObjectEntryTypeNVX
 import com.kgl.vulkan.enums.ObjectEntryUsageNVX
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.toVkType
 import cvulkan.VkObjectTableCreateInfoNVX
@@ -51,6 +52,10 @@ actual class ObjectTableCreateInfoNVXBuilder(internal val target: VkObjectTableC
 		set(value) {
 			target.maxPipelineLayouts = value.toVkType()
 		}
+
+	actual fun next(block: Next<ObjectTableCreateInfoNVXBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
 
 	internal actual fun init(
 			objectEntryTypes: Collection<ObjectEntryTypeNVX>,

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/PresentInfoKHRBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/PresentInfoKHRBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.core.VirtualStack
 import com.kgl.vulkan.handles.Semaphore
 import com.kgl.vulkan.handles.SwapchainKHR
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.mapToCArray
 import com.kgl.vulkan.utils.toVkType
 import cvulkan.VK_STRUCTURE_TYPE_PRESENT_INFO_KHR
@@ -25,6 +26,10 @@ import cvulkan.VkPresentInfoKHR
 import kotlinx.cinterop.value
 
 actual class PresentInfoKHRBuilder(internal val target: VkPresentInfoKHR) {
+	actual fun next(block: Next<PresentInfoKHRBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
+
 	internal actual fun init(swapchains: Collection<Pair<SwapchainKHR, UInt>>, waitSemaphores: Collection<Semaphore>?) {
 		target.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR
 		target.pNext = null

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/ShaderModuleCreateInfoBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/ShaderModuleCreateInfoBuilder.kt
@@ -15,11 +15,16 @@
  */
 package com.kgl.vulkan.dsls
 
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.toVkType
 import cvulkan.VkShaderModuleCreateInfo
 import kotlinx.cinterop.reinterpret
 
 actual class ShaderModuleCreateInfoBuilder(internal val target: VkShaderModuleCreateInfo) {
+	actual fun next(block: Next<ShaderModuleCreateInfoBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
+
 	internal actual fun init(code: UByteArray) {
 		target.sType = cvulkan.VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO
 		target.pNext = null

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/SubmitInfoBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/SubmitInfoBuilder.kt
@@ -18,11 +18,16 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.PipelineStage
 import com.kgl.vulkan.handles.CommandBuffer
 import com.kgl.vulkan.handles.Semaphore
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.toVkType
 import cvulkan.VkSubmitInfo
 
 actual class SubmitInfoBuilder(internal val target: VkSubmitInfo) {
+	actual fun next(block: Next<SubmitInfoBuilder>.() -> Unit) {
+		Next(this).apply(block)
+	}
+
 	internal actual fun init(
 			waitSemaphores: Collection<Pair<Semaphore, VkFlag<PipelineStage>>>?,
 			commandBuffers: Collection<CommandBuffer>?,

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/SubpassDescription2KHRBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/SubpassDescription2KHRBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.core.VirtualStack
 import com.kgl.vulkan.enums.PipelineBindPoint
 import com.kgl.vulkan.enums.SubpassDescription
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.mapToStackArray
 import com.kgl.vulkan.utils.toVkType
@@ -70,6 +71,10 @@ actual class SubpassDescription2KHRBuilder(internal val target: VkSubpassDescrip
 		val builder = AttachmentReference2KHRBuilder(subTarget)
 		builder.init()
 		builder.apply(block)
+	}
+
+	actual fun next(block: Next<SubpassDescription2KHRBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init(preserveAttachments: UIntArray) {

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/SubpassDescriptionBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/SubpassDescriptionBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.core.VirtualStack
 import com.kgl.vulkan.enums.PipelineBindPoint
 import com.kgl.vulkan.enums.SubpassDescription
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.VkFlag
 import com.kgl.vulkan.utils.mapToStackArray
 import com.kgl.vulkan.utils.toVkType
@@ -63,6 +64,10 @@ actual class SubpassDescriptionBuilder(internal val target: VkSubpassDescription
 		val builder = AttachmentReferenceBuilder(subTarget)
 		builder.init()
 		builder.apply(block)
+	}
+
+	actual fun next(block: Next<SubpassDescriptionBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init(preserveAttachments: UIntArray?) {

--- a/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/WriteDescriptorSetBuilder.kt
+++ b/kgl-vulkan/src/nativeMain/kotlin/com/kgl/vulkan/dsls/WriteDescriptorSetBuilder.kt
@@ -18,6 +18,7 @@ package com.kgl.vulkan.dsls
 import com.kgl.vulkan.enums.DescriptorType
 import com.kgl.vulkan.handles.BufferView
 import com.kgl.vulkan.handles.DescriptorSet
+import com.kgl.vulkan.utils.Next
 import com.kgl.vulkan.utils.mapToStackArray
 import com.kgl.vulkan.utils.toVkType
 import cvulkan.VkWriteDescriptorSet
@@ -51,6 +52,10 @@ actual class WriteDescriptorSetBuilder(internal val target: VkWriteDescriptorSet
 		val targets = DescriptorBufferInfosBuilder().apply(block).targets
 		target.pBufferInfo = targets.mapToStackArray(::DescriptorBufferInfoBuilder)
 		target.descriptorCount = targets.size.toUInt()
+	}
+
+	actual fun next(block: Next<WriteDescriptorSetBuilder>.() -> Unit) {
+		Next(this).apply(block)
 	}
 
 	internal actual fun init(dstSet: DescriptorSet, texelBufferView: Collection<BufferView>?) {


### PR DESCRIPTION
The generator now generates addition DSL methods for `pNext` extensions for input structs.
```kotlin
Instance.create(layers, extensions) {
    applicationInfo {
        applicationName = "Test"
        applicationVersion = VkVersion(1U, 1U, 0U)
        engineName = "No engine!"
        engineVersion = VkVersion(1U, 0U, 0U)
        apiVersion = VkVersion(1u, 0u, 0u)
    }

    // pNext !!!!
    next {
        ValidationFlagsEXT(listOf(ValidationCheckEXT.ALL_EXT, ValidationCheckEXT.SHADERS_EXT))

        DebugReportCallbackCreateInfoEXT {
            flags = DebugReportEXT.WARNING_BIT_EXT or DebugReportEXT.ERROR_BIT_EXT
            callback { _, _, _, _, _, _, message ->
                println("Debug Message: $message")
            }
        }

        DebugUtilsMessengerCreateInfoEXT {
            messageType = DebugUtilsMessageTypeEXT.GENERAL
            messageSeverity = DebugUtilsMessageSeverityEXT.ERROR

            userCallback { messageSeverity, messageTypes, callbackData ->
                println("$messageSeverity $messageTypes $callbackData")
            }
        }
    }
}
```

Closes #10 