### PR TITLE
Implement global window hint system and simplify window construction

### DIFF
--- a/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -28,6 +28,7 @@ expect object Glfw {
 
 	val version: GlfwVersion
 	val versionString: String
+	val windowHints: WindowHints
 
 	fun init(): Boolean
 	fun terminate()

--- a/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/Window.kt
@@ -17,7 +17,13 @@ package com.kgl.glfw
 
 import io.ktor.utils.io.core.Closeable
 
-expect class Window : Closeable {
+expect class Window(
+	width: Int,
+	height: Int,
+	title: String,
+	monitor: Monitor? = null,
+	share: Window? = null
+) : Closeable {
 	var position: Pair<Int, Int>
 	var size: Pair<Int, Int>
 	val frameBufferSize: Pair<Int, Int>
@@ -88,57 +94,4 @@ expect class Window : Closeable {
 	fun setMouseButtonCallback(callback: MouseButtonCallback?): MouseButtonCallback?
 	fun setCharCallback(callback: CharCallback?): CharCallback?
 	fun setCharModsCallback(callback: CharModsCallback?): CharModsCallback?
-
-	companion object {
-		inline operator fun invoke(
-				width: Int,
-				height: Int,
-				title: String,
-				monitor: Monitor? = null,
-				share: Window? = null,
-				block: Builder.() -> Unit
-		): Window
-	}
-
-	class Builder {
-		var clientApi: ClientApi
-		var contextCreationApi: CreationApi
-		var contextVersionMajor: Int
-		var contextVersionMinor: Int
-		var contextRobustness: Robustness
-		var releaseBehaviour: ReleaseBehaviour
-		var contextNoError: Boolean
-		var openGLForwardCompat: Boolean
-		var openGLDebugContext: Boolean
-		var openGLProfile: OpenGLProfile
-
-		var redBits: Int
-		var greenBits: Int
-		var blueBits: Int
-		var alphaBits: Int
-		var depthBits: Int
-		var stencilBits: Int
-		var accumRedBits: Int
-		var accumGreenBits: Int
-		var accumBlueBits: Int
-		var accumAlphaBits: Int
-		var samples: Int
-		var stereo: Boolean
-		var srgbCapable: Boolean
-		var doubleBuffer: Boolean
-
-		var resizable: Boolean
-		var visible: Boolean
-		var decorated: Boolean
-		var focused: Boolean
-		var autoIconify: Boolean
-		var floating: Boolean
-		var maximized: Boolean
-		var centerCursor: Boolean
-		var transparentFramebuffer: Boolean
-		var focusOnShow: Boolean
-		var scaleToMonitor: Boolean
-
-		var refreshRate: Int
-	}
 }

--- a/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/WindowHints.kt
+++ b/kgl-glfw/src/commonMain/kotlin/com/kgl/glfw/WindowHints.kt
@@ -1,0 +1,135 @@
+package com.kgl.glfw
+
+interface WindowHints {
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var resizable: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var visible: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var decorated: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var focused: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var autoIconify: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var floating: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var maximized: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var centerCursor: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var transparentFrameBuffer: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var focusOnShow: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var scaleToMonitor: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var redBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var greenBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var blueBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var alphaBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var depthBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var stencilBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var accumRedBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var accumGreenBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var accumBlueBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var accumAlphaBits: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var auxBuffers: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var stereo: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var samples: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var srgbCapable: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var doubleBuffer: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var refreshRate: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var clientApi: ClientApi
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var contextCreationApi: CreationApi
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var contextVersionMajor: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var contextVersionMinor: Int
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var openGLForwardCompat: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var openGLDebugContext: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var openGLProfile: OpenGLProfile
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var contextRobustness: Robustness
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var contextReleaseBehavior: ReleaseBehaviour
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var contextNoError: Boolean
+
+	// macOS-specific
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var cocoaRetinaFrameBuffer: Boolean
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var cocoaFrameName: String
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var cocoaGraphicsSwitching: Boolean
+
+	// X11-specific
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var x11ClassName: String
+
+	@get:Deprecated("Querying window hints is not supported", level = DeprecationLevel.ERROR)
+	var x11InstanceName: String
+
+	fun restoreDefaults()
+}

--- a/kgl-glfw/src/commonTest/kotlin/com/kgl/glfw/SampleTests.kt
+++ b/kgl-glfw/src/commonTest/kotlin/com/kgl/glfw/SampleTests.kt
@@ -15,9 +15,7 @@
  */
 package com.kgl.glfw
 
-import kotlin.test.Ignore
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class SampleTests {
 	@Test
@@ -29,23 +27,26 @@ class SampleTests {
 	@Test
 	@Ignore
 	fun testBasicWindow() {
-		val window = Window(640, 480, "Test window", null, null) {
-			clientApi = ClientApi.None
-		}
+		Glfw.init()
+		Glfw.windowHints.clientApi = ClientApi.None
+
+		val window = Window(640, 480, "Test window")
 
 		while (!window.shouldClose) {
 			Glfw.pollEvents()
 		}
 
 		window.close()
+		Glfw.terminate()
 	}
 
 	@Test
 	@Ignore
 	fun testPerformance() {
-		val window = Window(640, 480, "Test window", null, null) {
-			clientApi = ClientApi.None
-		}
+		Glfw.init()
+		Glfw.windowHints.clientApi = ClientApi.None
+
+		val window = Window(640, 480, "Test window", null, null)
 
 		val start = Glfw.time
 
@@ -60,5 +61,6 @@ class SampleTests {
 		println("Per: ${(end - start) / 10000}")
 
 		window.close()
+		Glfw.terminate()
 	}
 }

--- a/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -58,6 +58,178 @@ actual object Glfw {
 		}
 	actual val versionString: String get() = glfwGetVersionString()
 
+	actual val windowHints = object : WindowHints {
+		override var resizable: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_RESIZABLE, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var visible: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_VISIBLE, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var decorated: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_DECORATED, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var focused: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_FOCUSED, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var autoIconify: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_AUTO_ICONIFY, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var floating: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_FLOATING, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var maximized: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_MAXIMIZED, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var centerCursor: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CENTER_CURSOR, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var transparentFrameBuffer: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var focusOnShow: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_FOCUS_ON_SHOW, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var scaleToMonitor: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_SCALE_TO_MONITOR, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var redBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_RED_BITS, value)
+
+		override var greenBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_GREEN_BITS, value)
+
+		override var blueBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_BLUE_BITS, value)
+
+		override var alphaBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ALPHA_BITS, value)
+
+		override var depthBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_DEPTH_BITS, value)
+
+		override var stencilBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_STENCIL_BITS, value)
+
+		override var accumRedBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_RED_BITS, value)
+
+		override var accumGreenBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_GREEN_BITS, value)
+
+		override var accumBlueBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_BLUE_BITS, value)
+
+		override var accumAlphaBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_ALPHA_BITS, value)
+
+		override var auxBuffers: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_AUX_BUFFERS, value)
+
+		override var stereo: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_STEREO, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var samples: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_SAMPLES, value)
+
+		override var srgbCapable: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_SRGB_CAPABLE, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var doubleBuffer: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_DOUBLEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var refreshRate: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_REFRESH_RATE, value)
+
+		override var clientApi: ClientApi
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CLIENT_API, value.value)
+
+		override var contextCreationApi: CreationApi
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_CREATION_API, value.value)
+
+		override var contextVersionMajor: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, value)
+
+		override var contextVersionMinor: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, value)
+
+		override var openGLForwardCompat: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var openGLDebugContext: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var openGLProfile: OpenGLProfile
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_OPENGL_PROFILE, value.value)
+
+		override var contextRobustness: Robustness
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_ROBUSTNESS, value.value)
+
+		override var contextReleaseBehavior: ReleaseBehaviour
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_RELEASE_BEHAVIOR, value.value)
+
+		override var contextNoError: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_NO_ERROR, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var cocoaRetinaFrameBuffer: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var cocoaFrameName: String
+			get() = error("")
+			set(value) = glfwWindowHintString(GLFW_COCOA_FRAME_NAME, value)
+
+		override var cocoaGraphicsSwitching: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var x11ClassName: String
+			get() = error("")
+			set(value) = glfwWindowHintString(GLFW_X11_CLASS_NAME, value)
+
+		override var x11InstanceName: String
+			get() = error("")
+			set(value) = glfwWindowHintString(GLFW_X11_INSTANCE_NAME, value)
+
+		override fun restoreDefaults() = glfwDefaultWindowHints()
+	}
+
 	actual fun init(): Boolean = glfwInit()
 	actual fun terminate() {
 		glfwTerminate()

--- a/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Window.kt
+++ b/kgl-glfw/src/jvmMain/kotlin/com/kgl/glfw/Window.kt
@@ -15,18 +15,26 @@
  */
 package com.kgl.glfw
 
-import com.kgl.core.Flag
-import io.ktor.utils.io.core.Closeable
-import org.lwjgl.PointerBuffer
+import com.kgl.core.*
+import io.ktor.utils.io.core.*
+import org.lwjgl.*
 import org.lwjgl.glfw.*
 import org.lwjgl.glfw.GLFW.*
-import org.lwjgl.system.Callback
-import org.lwjgl.system.CallbackI
-import org.lwjgl.system.MemoryStack
-import org.lwjgl.system.MemoryUtil
-import org.lwjgl.system.jni.JNINativeInterface
+import org.lwjgl.system.*
+import org.lwjgl.system.jni.*
 
-actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeable {
+actual class Window private constructor(val ptr: Long) : Closeable {
+	actual constructor(
+		width: Int,
+		height: Int,
+		title: String,
+		monitor: Monitor?,
+		share: Window?
+	) : this(
+		glfwCreateWindow(width, height, title, monitor?.ptr ?: 0L, share?.ptr ?: 0L)
+			.takeIf { it != 0L }
+			?: throw Exception("Could not create window.")
+	)
 
 	init {
 		check(glfwGetWindowUserPointer(ptr) == 0L) {
@@ -309,11 +317,11 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 	private var charModsCallback: CharModsCallback? = null
 
 	private inline fun <TCallback, TNativeCallback : Callback, TNativeCallbackI : CallbackI> setCallback(
-			callback: TCallback?,
-			propGetter: () -> TCallback?,
-			propSetter: (TCallback?) -> Unit,
-			realSetter: (Long, TNativeCallbackI?) -> TNativeCallback?,
-			getNativeCallback: () -> TNativeCallbackI
+		callback: TCallback?,
+		propGetter: () -> TCallback?,
+		propSetter: (TCallback?) -> Unit,
+		realSetter: (Long, TNativeCallbackI?) -> TNativeCallback?,
+		getNativeCallback: () -> TNativeCallbackI
 	): TCallback? {
 		val previous = propGetter()
 		propSetter(callback)
@@ -513,244 +521,5 @@ actual class Window @PublishedApi internal constructor(val ptr: Long) : Closeabl
 		JNINativeInterface.DeleteGlobalRef(globalRef)
 
 		glfwDestroyWindow(ptr)
-	}
-
-	actual companion object {
-		actual inline operator fun invoke(
-				width: Int,
-				height: Int,
-				title: String,
-				monitor: Monitor?,
-				share: Window?,
-				block: Builder.() -> Unit
-		): Window {
-			check(glfwInit()) { "Could not init GLFW." }
-
-			glfwDefaultWindowHints()
-			Builder().block()
-
-			return Window(glfwCreateWindow(
-					width, height, title, monitor?.ptr ?: 0L, share?.ptr ?: 0L
-			).takeIf { it != 0L } ?: throw Exception("Could not create window."))
-		}
-	}
-
-	actual class Builder {
-		actual var clientApi: ClientApi
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CLIENT_API, value.value)
-			}
-
-		actual var contextCreationApi: CreationApi
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CONTEXT_CREATION_API, value.value)
-			}
-
-		actual var contextVersionMajor: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, value)
-			}
-
-		actual var contextVersionMinor: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, value)
-			}
-
-		actual var contextRobustness: Robustness
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CONTEXT_ROBUSTNESS, value.value)
-			}
-
-		actual var releaseBehaviour: ReleaseBehaviour
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CONTEXT_RELEASE_BEHAVIOR, value.value)
-			}
-
-		actual var contextNoError: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CONTEXT_NO_ERROR, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var openGLForwardCompat: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var openGLDebugContext: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var openGLProfile: OpenGLProfile
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_OPENGL_PROFILE, value.value)
-			}
-
-		actual var redBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_RED_BITS, value)
-			}
-
-		actual var greenBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_GREEN_BITS, value)
-			}
-
-		actual var blueBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_BLUE_BITS, value)
-			}
-
-		actual var alphaBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_ALPHA_BITS, value)
-			}
-
-		actual var depthBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_DEPTH_BITS, value)
-			}
-
-		actual var stencilBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_STENCIL_BITS, value)
-			}
-
-		actual var accumRedBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_ACCUM_RED_BITS, value)
-			}
-
-		actual var accumGreenBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_ACCUM_GREEN_BITS, value)
-			}
-
-		actual var accumBlueBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_ACCUM_BLUE_BITS, value)
-			}
-
-		actual var accumAlphaBits: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_ACCUM_ALPHA_BITS, value)
-			}
-
-		actual var samples: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_SAMPLES, value)
-			}
-
-		actual var stereo: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_STEREO, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var srgbCapable: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_SRGB_CAPABLE, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var doubleBuffer: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_DOUBLEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-
-		actual var resizable: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_RESIZABLE, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var visible: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_VISIBLE, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var decorated: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_DECORATED, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var focused: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_FOCUSED, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var autoIconify: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_AUTO_ICONIFY, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var floating: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_FLOATING, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var maximized: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_MAXIMIZED, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var centerCursor: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_CENTER_CURSOR, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var transparentFramebuffer: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var focusOnShow: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_FOCUS_ON_SHOW, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var scaleToMonitor: Boolean
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_SCALE_TO_MONITOR, if (value) GLFW_TRUE else GLFW_FALSE)
-			}
-
-		actual var refreshRate: Int
-			get() = TODO("Querying window hints is not supported")
-			set(value) {
-				glfwWindowHint(GLFW_REFRESH_RATE, value)
-			}
 	}
 }

--- a/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Glfw.kt
+++ b/kgl-glfw/src/nativeMain/kotlin/com/kgl/glfw/Glfw.kt
@@ -72,6 +72,178 @@ actual object Glfw {
 		}
 	actual val versionString: String get() = glfwGetVersionString()!!.toKString()
 
+	actual val windowHints = object : WindowHints {
+		override var resizable: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_RESIZABLE, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var visible: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_VISIBLE, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var decorated: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_DECORATED, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var focused: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_FOCUSED, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var autoIconify: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_AUTO_ICONIFY, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var floating: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_FLOATING, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var maximized: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_MAXIMIZED, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var centerCursor: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CENTER_CURSOR, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var transparentFrameBuffer: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var focusOnShow: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_FOCUS_ON_SHOW, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var scaleToMonitor: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_SCALE_TO_MONITOR, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var redBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_RED_BITS, value)
+
+		override var greenBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_GREEN_BITS, value)
+
+		override var blueBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_BLUE_BITS, value)
+
+		override var alphaBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ALPHA_BITS, value)
+
+		override var depthBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_DEPTH_BITS, value)
+
+		override var stencilBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_STENCIL_BITS, value)
+
+		override var accumRedBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_RED_BITS, value)
+
+		override var accumGreenBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_GREEN_BITS, value)
+
+		override var accumBlueBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_BLUE_BITS, value)
+
+		override var accumAlphaBits: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_ACCUM_ALPHA_BITS, value)
+
+		override var auxBuffers: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_AUX_BUFFERS, value)
+
+		override var stereo: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_STEREO, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var samples: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_SAMPLES, value)
+
+		override var srgbCapable: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_SRGB_CAPABLE, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var doubleBuffer: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_DOUBLEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var refreshRate: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_REFRESH_RATE, value)
+
+		override var clientApi: ClientApi
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CLIENT_API, value.value)
+
+		override var contextCreationApi: CreationApi
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_CREATION_API, value.value)
+
+		override var contextVersionMajor: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, value)
+
+		override var contextVersionMinor: Int
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, value)
+
+		override var openGLForwardCompat: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var openGLDebugContext: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var openGLProfile: OpenGLProfile
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_OPENGL_PROFILE, value.value)
+
+		override var contextRobustness: Robustness
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_ROBUSTNESS, value.value)
+
+		override var contextReleaseBehavior: ReleaseBehaviour
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_RELEASE_BEHAVIOR, value.value)
+
+		override var contextNoError: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_CONTEXT_NO_ERROR, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var cocoaRetinaFrameBuffer: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var cocoaFrameName: String
+			get() = error("")
+			set(value) = glfwWindowHintString(GLFW_COCOA_FRAME_NAME, value)
+
+		override var cocoaGraphicsSwitching: Boolean
+			get() = error("")
+			set(value) = glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, if (value) GLFW_TRUE else GLFW_FALSE)
+
+		override var x11ClassName: String
+			get() = error("")
+			set(value) = glfwWindowHintString(GLFW_X11_CLASS_NAME, value)
+
+		override var x11InstanceName: String
+			get() = error("")
+			set(value) = glfwWindowHintString(GLFW_X11_INSTANCE_NAME, value)
+
+		override fun restoreDefaults() = glfwDefaultWindowHints()
+	}
+
 	actual fun init(): Boolean = glfwInit() == GLFW_TRUE
 	actual fun terminate() {
 		glfwTerminate()


### PR DESCRIPTION
Added:
- WindowHints interface

Changed:
- Window constructor no longer calls glfwInit nor glfwDefaultWindowHints. These are expected to be called by the user.

Removed:
- Window hints from window constructor and Window.Builder class